### PR TITLE
Standardize callback model

### DIFF
--- a/packages/kujira-fin/src/execute.rs
+++ b/packages/kujira-fin/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary, Coin, Decimal256, Uint128, Uint256};
-use kujira_std::{Callback, Precision};
+use cosmwasm_std::{Addr, Coin, Decimal256, Uint128, Uint256};
+use kujira_std::{CallbackData, Precision};
 
 /// Callable interfaces
 #[cw_serde]
@@ -27,7 +27,7 @@ pub enum ExecuteMsg {
     SubmitOrder {
         /// The price of the order in terms of the quote denom. See [InstantiateMsg::denoms]
         price: Decimal256,
-        callback: Option<Callback>,
+        callback: Option<CallbackData>,
     },
 
     /// Executes a market trade based on current order book.
@@ -44,7 +44,7 @@ pub enum ExecuteMsg {
         /// An optional callback that FIN will execute with the funds from the swap.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<Callback>,
+        callback: Option<CallbackData>,
     },
 
     /// Retract the order and withdraw funds
@@ -58,7 +58,7 @@ pub enum ExecuteMsg {
         /// An optional callback that FIN will execute with the funds from the retraction.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<Callback>,
+        callback: Option<CallbackData>,
     },
 
     /// Fully retract orders and withdraw funds
@@ -69,7 +69,7 @@ pub enum ExecuteMsg {
         /// An optional callback that FIN will execute with the funds from the retractions.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<Callback>,
+        callback: Option<CallbackData>,
     },
 
     /// Claim filled orders
@@ -82,17 +82,11 @@ pub enum ExecuteMsg {
         /// An optional callback that FIN will execute with the funds from the withdrawals.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<Callback>,
+        callback: Option<CallbackData>,
     },
 }
 
 #[cw_serde]
-pub struct NewOrderCallback {
-    pub t: Binary,
+pub struct NewOrderData {
     pub idx: Uint128,
-}
-
-#[cw_serde]
-pub enum FINCallbackExecuteMsg {
-    OnSubmittedOrder(NewOrderCallback),
 }

--- a/packages/kujira-orca/src/execute.rs
+++ b/packages/kujira-orca/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Decimal, Uint128};
-use kujira_std::{CallbackMsg, Denom, Proof};
+use kujira_std::{CallbackData, Denom, Proof};
 
 /// Callable interfaces
 #[cw_serde]
@@ -95,7 +95,7 @@ pub enum ExecuteMsg {
         /// An optional callback that ORCA will execute with the funds from the liquidation.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<CallbackMsg>,
+        callback: Option<CallbackData>,
     },
     /// Register a custom swapper to support different [repay](ExecuteMsg::ExecuteLiquidation::repay_denom)
     /// and [bid](InstantiateMsg::bid_denom) denoms

--- a/packages/kujira-orca/src/execute.rs
+++ b/packages/kujira-orca/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Decimal, Uint128};
-use kujira_std::{Callback, Denom, Proof};
+use kujira_std::{CallbackMsg, Denom, Proof};
 
 /// Callable interfaces
 #[cw_serde]
@@ -95,7 +95,7 @@ pub enum ExecuteMsg {
         /// An optional callback that ORCA will execute with the funds from the liquidation.
         /// The callback is executed on the sender's address.
         /// NB: This is currently pre-release, and not yet available on production contracts
-        callback: Option<Callback>,
+        callback: Option<CallbackMsg>,
     },
     /// Register a custom swapper to support different [repay](ExecuteMsg::ExecuteLiquidation::repay_denom)
     /// and [bid](InstantiateMsg::bid_denom) denoms

--- a/packages/kujira-stable/src/limit/execute.rs
+++ b/packages/kujira-stable/src/limit/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Decimal256, Uint128};
-use kujira_fin::NewOrderCallback;
+use kujira_std::CallbackMsg;
 
 use crate::market;
 
@@ -37,11 +37,10 @@ pub enum ExecuteMsg {
 
     /// Callbacks, for internal use. Cannot (and should not) be called directly.
     Callback(CallbackMsg),
-    OnSubmittedOrder(NewOrderCallback),
 }
 
 #[cw_serde]
-pub enum CallbackMsg {
+pub enum CallbackType {
     /// Simply recalculates the amount of collateral on a position after withdrawing it from FIN.
     /// Used for both Close and Liquidate flows.
     WithdrawOrderCallback { position_idx: Uint128 },

--- a/packages/kujira-std/src/callback.rs
+++ b/packages/kujira-std/src/callback.rs
@@ -1,19 +1,60 @@
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary, Coin, CosmosMsg, WasmMsg};
+use cosmwasm_schema::{
+    cw_serde,
+    serde::{de::DeserializeOwned, Serialize},
+};
+use cosmwasm_std::{from_binary, to_binary, Addr, Binary, Coin, CosmosMsg, StdResult, WasmMsg};
 
 #[cw_serde]
-pub struct Callback(pub Binary);
+pub struct CallbackMsg {
+    pub data: Binary,
+    pub callback: CallbackData,
+}
+#[cw_serde]
+pub struct CallbackData(pub Binary);
 
-impl Callback {
-    pub fn to_message<T>(&self, cb_addr: &Addr, funds: &[Coin]) -> CosmosMsg<T> {
-        CosmosMsg::Wasm(WasmMsg::Execute {
+#[cw_serde]
+/// Serialization Helper for Callbacks
+enum ReceiverExecuteMsg {
+    Callback(CallbackMsg),
+}
+
+impl CallbackData {
+    pub fn to_message<T>(
+        &self,
+        cb_addr: &Addr,
+        data: impl Serialize,
+        funds: &[Coin],
+    ) -> StdResult<CosmosMsg<T>> {
+        let msg = CallbackMsg {
+            data: to_binary(&data)?,
+            callback: self.clone(),
+        };
+        Ok(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: cb_addr.to_string(),
-            msg: self.0.clone(),
+            msg: to_binary(&ReceiverExecuteMsg::Callback(msg))?,
             funds: funds.to_owned(),
-        })
+        }))
     }
 
     pub fn into_binary(self) -> Binary {
         self.0
+    }
+}
+
+impl CallbackMsg {
+    pub fn deserialize<D: DeserializeOwned, CB: DeserializeOwned>(self) -> StdResult<(D, CB)> {
+        let data = from_binary(&self.data)?;
+        let callback = from_binary(&self.callback.into_binary())?;
+        Ok((data, callback))
+    }
+
+    pub fn deserialize_data<D: DeserializeOwned>(self) -> StdResult<D> {
+        let data = from_binary(&self.data)?;
+        Ok(data)
+    }
+
+    pub fn deserialize_callback<CB: DeserializeOwned>(self) -> StdResult<CB> {
+        let callback = from_binary(&self.callback.into_binary())?;
+        Ok(callback)
     }
 }

--- a/packages/kujira-std/src/lib.rs
+++ b/packages/kujira-std/src/lib.rs
@@ -12,7 +12,7 @@ mod utils;
 
 pub use {
     asset::{Asset, AssetInfo},
-    callback::Callback,
+    callback::{CallbackData, CallbackMsg},
     denom::Denom,
     merkle::{Error as MerkleError, Merkle, Proof},
     msg::{AuthMsg, DenomMsg, KujiraMsg},


### PR DESCRIPTION
Execute messages should accept `Option<CallbackData>`, and then use e.g.:

```rust
// Some attributes / info to return with the callback, for example:
let data = NewOrderData { order_idx: ... };
msg.callback.map(|cb| cb.to_message(info.sender, data, coins(...)));
// Add message if it is not None, use a plain BankMsg send if msg is None and funds still need transferring.
```

Then on the receiver side, we have:

```rust
match msg {
    ...,
    ExecuteMsg::Callback(cb) => {
        let cb_type: CallbackType = cb.deserialize_callback()?;
        match cb_type {
            CallbackType::DoSomething { args } => {
                let data: NewOrderData = cb.deserialize_data()?;
            },
            ...
        }
    }
}
```
        